### PR TITLE
Add Masataka Okabe color blind friendly palette

### DIFF
--- a/colorpicker/public/colors/colors.json
+++ b/colorpicker/public/colors/colors.json
@@ -353,5 +353,19 @@
         "colors": ["#121212", "#191919", "#252525", "#0A0A0A", "#1B1B1B", "#212427", "#0C0C0C", "#0B1215", "#222428", "#100D08", "#1D1F21", "#101720", "#212A37", "#232023", "#161618", "#181818", "#11181C", "#212124", "#2A2A2A", "#242526", "#212121"]
       }
     ]
+  },
+  {
+    "collection": "Masataka Okabe",
+    "collection_source": {
+      "url": "https://jfly.uni-koeln.de/color",
+      "name": "Masataka Okabe"
+    },
+    "color_schemes": [
+      {
+        "name": "Color Blind",
+        "labels": ["categorical", "color_blind_friendly"],
+        "colors": ["#000000", "#e69f00", "#56b4e9", "#009e73", "#f0e442", "#0071b2", "#d55e00", "#cc79a7"]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- Add new color blind friendly palette from Masataka Okabe's research
- Provides 8 carefully selected colors optimized for color blind accessibility
- Based on scientific research from the University of Cologne

## Changes Made
- **New Collection**: "Masataka Okabe" color collection
- **8-Color Palette**: Includes black, orange, sky blue, bluish green, yellow, blue, vermillion, and reddish purple
- **Accessibility Labels**: Tagged as both "categorical" and "color_blind_friendly"
- **Research-Based**: Colors selected based on vision science research

## Color Palette Details
The palette includes these hex colors:
- #000000 (Black)
- #e69f00 (Orange) 
- #56b4e9 (Sky Blue)
- #009e73 (Bluish Green)
- #f0e442 (Yellow)
- #0071b2 (Blue)
- #d55e00 (Vermillion)
- #cc79a7 (Reddish Purple)

## Source
Based on research from https://jfly.uni-koeln.de/color - "Color Universal Design" by Masataka Okabe and Kei Ito.

## Test Plan
- [x] Verify new palette appears in the color picker
- [x] Confirm color blind friendly filtering works correctly
- [x] Check that all colors copy to clipboard properly
- [x] Validate source link navigates correctly

🤖 Generated with [Claude Code](https://claude.ai/code)